### PR TITLE
Report error rather than panicking with `unreachable!`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -103,6 +103,11 @@ pub enum WsErr
 	#[ error( "Received a message that is neither ArrayBuffer, String or Blob." ) ]
 	//
 	UnknownDataType,
+
+    /// Fallback whenever explicit variant hadling hansn't yet been implemented.
+    #[error("`{0}`")]
+    //
+    Other(String),
 }
 
 

--- a/src/ws_meta.rs
+++ b/src/ws_meta.rs
@@ -83,7 +83,7 @@ impl WsMeta
 						return Err( WsErr::InvalidUrl{ supplied: url.as_ref().to_string() } ),
 
 
-					_ => unreachable!(),
+					_ => return Err(WsErr::Other(de.message())),
 				};
 			}
 		};


### PR DESCRIPTION
The title should be somewhat self-explanatory. Had a project of my crash when reaching the previous `unreachable!` without any explanation in the error.  Turns out the error message was "The operation is insecure.", which is not necessarily a bug of itself: https://stackoverflow.com/questions/11768221/firefox-websocket-security-issue/12042843#12042843