### PR TITLE
fix send binary with target_feature = atomics

### DIFF
--- a/src/ws_stream.rs
+++ b/src/ws_stream.rs
@@ -311,8 +311,13 @@ impl Sink<WsMessage> for WsStream
 				//
 				match item
 				{
-					WsMessage::Binary( d ) => self.ws.send_with_u8_array( &d ).map_err( |_| WsErr::ConnectionNotOpen )? ,
-					WsMessage::Text  ( s ) => self.ws.send_with_str     ( &s ).map_err( |_| WsErr::ConnectionNotOpen )? ,
+					#[cfg(not(target_feature = "atomics"))]
+					WsMessage::Binary( d ) => self.ws.send_with_u8_array   ( &d )                               .map_err( |_| WsErr::ConnectionNotOpen )? ,
+					// The `atomics` feature enables shared memory, which cannot be passed to WebSocket::send_with_u8_array directly 
+					// as it could theoretically be mutated while the socket is reading it. We must make a js copy and send that.
+					#[cfg(target_feature = "atomics")]
+					WsMessage::Binary( d ) => self.ws.send_with_js_u8_array( &Uint8Array::from( d.as_slice() ) ).map_err( |_| WsErr::ConnectionNotOpen )? ,
+					WsMessage::Text  ( s ) => self.ws.send_with_str        ( &s )                               .map_err( |_| WsErr::ConnectionNotOpen )? ,
 				}
 
 				Ok(())


### PR DESCRIPTION
fixes #12

we can't pass rust memory to `WebSocket::send_with_u8_array` when `target_feature="atomics"` as this uses a `SharedArrayBuffer` memory, which js believes could be modified in flight. use a `send_with_js_u8_array` instead