### PR TITLE
remove cdylib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ version = "^0.7"
 tokio_io = ["async_io_stream/tokio_io"]
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [package]
 authors = ["Naja Melan <najamelan@autistici.org>"]


### PR DESCRIPTION
i found that trying to use this crate in a wasm project that uses `-Zbuild-std` fails with a duplicate symbol error:

```
error[E0152]: duplicate lang item in crate `core`: `sized`                                                                               
  |
  = note: the lang item is first defined in crate `core` (which `ws_stream_wasm` depends on)
  = note: first definition in `core` loaded from [...]\wasm-build-error\target\wasm32-unknown-unknown\debug\deps\libcore-f085fdbc4d4112f6.rlib, [...]\wasm-build-error\target\wasm32-unknown-unknown\debug\deps\libcore-f085fdbc4d4112f6.rmeta
  = note: second definition in `core` loaded from [...]\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\wasm32-unknown-unknown\lib\libcore-8d86a012fba24de9.rlib
```

i wanted to use various features including `panic=unwind`, hence the need to rebuild std. 

if i remove the "cdylib" target, it builds successfully. i am not totally clear on what that target is there for, could it be removed?